### PR TITLE
两个特性: 增加g++编译支持;避免非法指令导致的卡死

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,25 @@
 CXXFLAGS += $(shell llvm-config --cxxflags) -O2
 LIBS += $(shell llvm-config --libs)
-LDFLAGS += $(shell llvm-config --ldflags) -flto=thin 
+LDFLAGS += $(shell llvm-config --ldflags)
 LDFLAGS += $(shell if command -v mold --version >/dev/null 2>&1; then echo "-fuse-ld=mold"; fi)
 SRCS = $(wildcard src/*.cpp)
 FLAGS = $(CXXFLAGS) $(LDFLAGS) $(LIBS)
 BUILDDIR = bin
+CC = clang++
+
+ifeq ($(CC), clang++)
+	LDFLAGS += -flto=thin 
+endif
 
 all: $(BUILDDIR)/gtkwave-filter-rv64 $(BUILDDIR)/gtkwave-filter-rv32
 
 $(BUILDDIR)/gtkwave-filter-rv32: $(SRCS) | $(BUILDDIR)
-	clang++ $(FLAGS) $^ -o $@ -DTARGET="riscv32"
+	@echo + CC "->" filter-32
+	@$(CC) $^ $(FLAGS) -o $@ -DTARGET="riscv32"
 
 $(BUILDDIR)/gtkwave-filter-rv64: $(SRCS) | $(BUILDDIR)
-	clang++ $(FLAGS) $^ -o $@ -DTARGET="riscv64"	
+	@echo + CC "->" filter-64
+	@$(CC) $^ $(FLAGS) -o $@ -DTARGET="riscv64"	
 
 $(BUILDDIR):
 	mkdir -p $(BUILDDIR)

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -14,9 +14,6 @@
  * See the Mulan PSL v2 for more details.
  ***************************************************************************************/
 
-#include <sstream>
-#include <iomanip>
-
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
@@ -100,13 +97,12 @@ std::string disassemble(uint64_t hx) {
     MCInst inst;
     llvm::ArrayRef<uint8_t> arr(code, 4);
     uint64_t dummy_size = 0, addr = 0;
-    if(gDisassembler->getInstruction(inst, dummy_size, arr, addr, llvm::nulls()) != MCDisassembler::Success){
-        std::stringstream stream;
-        stream << "invalid inst:" << std::hex << hx;
-        return stream.str();
-    }
     std::string s;
     raw_string_ostream os(s);
+    if(gDisassembler->getInstruction(inst, dummy_size, arr, addr, llvm::nulls()) != MCDisassembler::Success){
+        os << "invalid inst:" << llvm::format_hex_no_prefix(hx,8);
+        return s;
+    }
     gIP->printInst(&inst, addr, "", *gSTI, os);
 
     // Assume result format "\tOpName\tOperands"

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -14,6 +14,9 @@
  * See the Mulan PSL v2 for more details.
  ***************************************************************************************/
 
+#include <sstream>
+#include <iomanip>
+
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
@@ -92,12 +95,16 @@ void init_disasm(std::string triple) {
     gIP->applyTargetSpecificCLOption("no-aliases");
 }
 
-std::string disassemble(uint8_t *code) {
+std::string disassemble(uint64_t hx) {
+    uint8_t *code = reinterpret_cast<uint8_t *>(&hx);
     MCInst inst;
     llvm::ArrayRef<uint8_t> arr(code, 4);
     uint64_t dummy_size = 0, addr = 0;
-    gDisassembler->getInstruction(inst, dummy_size, arr, addr, llvm::nulls());
-
+    if(gDisassembler->getInstruction(inst, dummy_size, arr, addr, llvm::nulls()) != MCDisassembler::Success){
+        std::stringstream stream;
+        stream << "invalid inst:" << std::hex << hx;
+        return stream.str();
+    }
     std::string s;
     raw_string_ostream os(s);
     gIP->printInst(&inst, addr, "", *gSTI, os);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,7 +24,7 @@
 #define TARGET riscv32
 #endif
 
-std::string disassemble(uint8_t *code);
+std::string disassemble(uint64_t);
 void init_disasm(std::string triple);
 
 int main() {
@@ -34,7 +34,7 @@ int main() {
     while (std::cin >> buf) {
         std::istringstream iss(buf);
         iss >> std::hex >> hx;
-        ret_string = disassemble(reinterpret_cast<uint8_t *>(&hx));
+        ret_string = disassemble(hx);
         std::cout << ret_string << std::endl;
     }
     return 0;


### PR DESCRIPTION

### commit 69b8296a437aeee7397c0b05297e0672ed49c2d9 : 
- 增加g++编译的支持
  在O2下的性能 g++ < clang++ < clang++ -flto=thin
  性能差均距约在0.5%以下: 
  测试脚本`time yes "73" | head -n 10000000 | bin/gtkwave-filter-rv32 > /dev/null`
  > g++: 8.50s
  clang++: 8.45s
  clang++ -flto=thin:   8.42s

### commit 234c9691b151110e655e3b044357056e2ea8d120 : 
- 当解析非法指令时,程序会异常退出,导致gtkwave卡死
  g++ `signal SIGILL (Illegal instruction)`
  clang++ `signal SIGSEGV (Address boundary error)`
  返回"invalid inst: $(inst)",避免卡死的问题
  ![Screenshot from 2024-01-28 18-17-31](https://github.com/FurryAcetylCoA/gtkwave-filter-process-RISC-V/assets/81887980/70882b6d-c112-405d-82e5-c34ccef5a032)
---
## 在加入 234c9691b151110e655e3b044357056e2ea8d120 的特性后 g++ 的性能反而高
### 但是我认为这些性能差距都可以忽略
合法指令(ecall)测试脚本`time yes "73" | head -n 10000000 | bin/gtkwave-filter-rv32 > /dev/null`
> g++: 8.32s
  clang++ 8.42s
  clang++ -flto=thin:   8.42s  

非法指令测试脚本`time yes "10" | head -n 10000000 | bin/gtkwave-filter-rv32 > /dev/null` 
> g++: 8.12s
  clang++ 8.26s
  clang++ -flto=thin:   8.20s