### PR TITLE
fix the support of loongarch32

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ### Support targets:
 * RISC-V 32/64 with M/A/F/D
-* LoongArch32 reduce
+* LoongArch32
 
 ### Usage 
 1) Highlight the signals you want filtered

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -72,9 +72,7 @@ void init_disasm(std::string triple) {
     	gSTI->ApplyFeatureFlag("+a");
     	// gSTI->ApplyFeatureFlag("+c");
     	gSTI->ApplyFeatureFlag("+f");
-    	gSTI->ApplyFeatureFlag("+d");
-    }else if(isa == "loongarch32"){
-
+        gSTI->ApplyFeatureFlag("+d");
     }
     gMII = target->createMCInstrInfo();
     gMRI = target->createMCRegInfo(triple);
@@ -91,7 +89,8 @@ void init_disasm(std::string triple) {
                                       AsmInfo->getAssemblerDialect(), *AsmInfo,
                                       *gMII, *gMRI);
     gIP->setPrintImmHex(true);
-    gIP->applyTargetSpecificCLOption("no-aliases");
+    if (isa == "riscv32" || isa == "riscv64")
+        gIP->applyTargetSpecificCLOption("no-aliases");
 }
 
 std::string disassemble(uint64_t hx) {


### PR DESCRIPTION
The `no-aliases` option is RISC-V-specific.