### PR TITLE
添加mips32（大端序）和mipsel32（小端序）支持，disasm中添加debug宏，在控制台中显示当前转译指令对应的16进制与2进制

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SRCS = $(wildcard src/*.cpp)
 BUILDDIR = bin
 FLAGS = $(CXXFLAGS) $(LDFLAGS) $(LIBS)
 
-all: $(BUILDDIR)/gtkwave-filter-rv64 $(BUILDDIR)/gtkwave-filter-rv32 $(BUILDDIR)/gtkwave-filter-la32
+all: $(BUILDDIR)/gtkwave-filter-rv64 $(BUILDDIR)/gtkwave-filter-rv32 $(BUILDDIR)/gtkwave-filter-la32 $(BUILDDIR)/gtkwave-filter-mips32 $(BUILDDIR)/gtkwave-filter-mipsel32
 
 $(BUILDDIR)/gtkwave-filter-rv32: $(SRCS) | $(BUILDDIR)
 	@echo + CXX "->" $@
@@ -21,6 +21,14 @@ $(BUILDDIR)/gtkwave-filter-rv64: $(SRCS) | $(BUILDDIR)
 $(BUILDDIR)/gtkwave-filter-la32: $(SRCS) | $(BUILDDIR)
 	@echo + CXX "->" $@
 	$(CXX) $^ $(FLAGS) -o $@ -DTARGET="loongarch32"
+
+$(BUILDDIR)/gtkwave-filter-mips32: $(SRCS) | $(BUILDDIR)
+	@echo + CXX "->" $@
+	$(CXX) $^ $(FLAGS) -o $@ -DTARGET="mips"
+
+$(BUILDDIR)/gtkwave-filter-mipsel32: $(SRCS) | $(BUILDDIR)
+	@echo + CXX "->" $@
+	$(CXX) $^ $(FLAGS) -o $@ -DTARGET="mipsel"
 
 
 $(BUILDDIR):


### PR DESCRIPTION
cpu设计实战中使用的是mipsel指令集，不清楚龙芯杯对大小端序的具体要求，所以将mips和mipsel都写上了