### PR TITLE
添加mips32（大端序）和mipsel32（小端序）支持，disasm中添加debug宏，在控制台中显示当前转译指令对应的16进制与2进制

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SRCS = $(wildcard src/*.cpp)
 BUILDDIR = bin
 FLAGS = $(CXXFLAGS) $(LDFLAGS) $(LIBS)
 
-all: $(BUILDDIR)/gtkwave-filter-rv64 $(BUILDDIR)/gtkwave-filter-rv32 $(BUILDDIR)/gtkwave-filter-la32
+all: $(BUILDDIR)/gtkwave-filter-rv64 $(BUILDDIR)/gtkwave-filter-rv32 $(BUILDDIR)/gtkwave-filter-la32 $(BUILDDIR)/gtkwave-filter-mips32 $(BUILDDIR)/gtkwave-filter-mipsel32
 
 $(BUILDDIR)/gtkwave-filter-rv32: $(SRCS) | $(BUILDDIR)
 	@echo + CXX "->" $@
@@ -21,6 +21,14 @@ $(BUILDDIR)/gtkwave-filter-rv64: $(SRCS) | $(BUILDDIR)
 $(BUILDDIR)/gtkwave-filter-la32: $(SRCS) | $(BUILDDIR)
 	@echo + CXX "->" $@
 	$(CXX) $^ $(FLAGS) -o $@ -DTARGET="loongarch32"
+
+$(BUILDDIR)/gtkwave-filter-mips32: $(SRCS) | $(BUILDDIR)
+	@echo + CXX "->" $@
+	$(CXX) $^ $(FLAGS) -o $@ -DTARGET="mips"
+
+$(BUILDDIR)/gtkwave-filter-mipsel32: $(SRCS) | $(BUILDDIR)
+	@echo + CXX "->" $@
+	$(CXX) $^ $(FLAGS) -o $@ -DTARGET="mipsel"
 
 
 $(BUILDDIR):

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 ### Support targets:
 * RISC-V 32/64 with M/A/F/D
 * LoongArch32
+* Mips/Mipsel 32
 
 ### Usage 
 1) Highlight the signals you want filtered

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -23,6 +23,7 @@
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCDisassembler/MCDisassembler.h"
 #include "llvm/MC/MCInstPrinter.h"
+#include "llvm/Support/FormatVariadic.h"
 #if LLVM_VERSION_MAJOR >= 14
 #include "llvm/MC/TargetRegistry.h"
 #if LLVM_VERSION_MAJOR >= 15
@@ -40,6 +41,8 @@
 #if LLVM_VERSION_MAJOR < 11
 #error Please use LLVM with major version >= 11
 #endif
+
+#define DEBUG_DISPLAY true
 
 using namespace llvm;
 
@@ -91,6 +94,7 @@ void init_disasm(std::string triple) {
     gIP->setPrintImmHex(true);
     if (isa == "riscv32" || isa == "riscv64")
         gIP->applyTargetSpecificCLOption("no-aliases");
+    
 }
 
 std::string disassemble(uint64_t hx) {
@@ -103,7 +107,12 @@ std::string disassemble(uint64_t hx) {
     if(gDisassembler->getInstruction(inst, dummy_size, arr, addr, llvm::nulls()) != MCDisassembler::Success){
         os << "invalid inst:" << llvm::format_hex_no_prefix(hx,8);
         return s;
-    }
+    }else if(DEBUG_DISPLAY){
+		llvm::errs() << "cursor inst: (HEX)" << llvm::format_hex_no_prefix(hx,8) << " ";
+		llvm::APInt hex_value(64, hx);
+		llvm::errs() << "(BIN)" << toString(hex_value,2,false) <<"\n";
+	}
+
     gIP->printInst(&inst, addr, "", *gSTI, os);
 
     // Assume result format "\tOpName\tOperands"


### PR DESCRIPTION
由于龙芯杯是mipsel32的，因此把大小端序全部加上了