### PR TITLE
添加disasm中添加debug宏，在控制台中显示当前转译指令对应的16进制与2进制

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SRCS = $(wildcard src/*.cpp)
 BUILDDIR = bin
 FLAGS = $(CXXFLAGS) $(LDFLAGS) $(LIBS)
 
-all: $(BUILDDIR)/gtkwave-filter-rv64 $(BUILDDIR)/gtkwave-filter-rv32 $(BUILDDIR)/gtkwave-filter-la32
+all: $(BUILDDIR)/gtkwave-filter-rv64 $(BUILDDIR)/gtkwave-filter-rv32 $(BUILDDIR)/gtkwave-filter-la32 
 
 $(BUILDDIR)/gtkwave-filter-rv32: $(SRCS) | $(BUILDDIR)
 	@echo + CXX "->" $@

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -41,6 +41,8 @@
 #error Please use LLVM with major version >= 11
 #endif
 
+#define DEBUG_DISPLAY true
+
 using namespace llvm;
 
 static llvm::MCDisassembler *gDisassembler = nullptr;
@@ -103,7 +105,12 @@ std::string disassemble(uint64_t hx) {
     if(gDisassembler->getInstruction(inst, dummy_size, arr, addr, llvm::nulls()) != MCDisassembler::Success){
         os << "invalid inst:" << llvm::format_hex_no_prefix(hx,8);
         return s;
-    }
+    }else if(DEBUG_DISPLAY){
+		llvm::errs() << "cursor inst: (HEX)" << llvm::format_hex_no_prefix(hx,8) << " ";
+		llvm::APInt hex_value(64, hx);
+		llvm::errs() << "(BIN)" << toString(hex_value,2,false) <<"\n";
+	}
+
     gIP->printInst(&inst, addr, "", *gSTI, os);
 
     // Assume result format "\tOpName\tOperands"


### PR DESCRIPTION
仅留下了debug宏